### PR TITLE
Add Supabase-backed time spans

### DIFF
--- a/src/app/(authenticated)/layout.tsx
+++ b/src/app/(authenticated)/layout.tsx
@@ -1,5 +1,6 @@
 import AdminPanelLayout from "@/components/admin-panel/admin-panel-layout";
 import { SupabaseDataProvider } from "@/contexts/SupabaseContext";
+import { SettingsProvider } from "@/contexts/SettingsContext";
 import { createClient } from "@/utils/supabase/server";
 import { redirect } from "next/navigation";
 
@@ -15,7 +16,9 @@ export default async function DemoLayout({
     }
   return(
   <SupabaseDataProvider>
+    <SettingsProvider>
       <AdminPanelLayout>{children}</AdminPanelLayout>
+    </SettingsProvider>
   </SupabaseDataProvider>
   );
 }

--- a/src/app/api/time-spans/route.ts
+++ b/src/app/api/time-spans/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/utils/supabase/server";
+
+export async function GET() {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("time_spans")
+    .select("*")
+    .order("id");
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json(data ?? []);
+}
+
+export async function POST(request: Request) {
+  const supabase = createClient();
+  const body = await request.json();
+  const { data, error } = await supabase
+    .from("time_spans")
+    .insert({
+      name: body.name,
+      start_time: body.start_time,
+      end_time: body.end_time,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json(data);
+}
+
+export async function PUT(request: Request) {
+  const supabase = createClient();
+  const body = await request.json();
+  const { data, error } = await supabase
+    .from("time_spans")
+    .update({
+      name: body.name,
+      start_time: body.start_time,
+      end_time: body.end_time,
+    })
+    .eq("id", body.id)
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json(data);
+}

--- a/src/components/admin-panel/schedule/Scheduler.tsx
+++ b/src/components/admin-panel/schedule/Scheduler.tsx
@@ -14,11 +14,7 @@ import clsx from 'clsx';
 import EditShiftDialog from './EditShiftDialog';
 import InfoShiftDialog from './InfoShiftDialog';
 import { useSupabaseData } from '@/contexts/SupabaseContext';
-const timeSpans = {
-  morning: { start: '06:00', end: '11:59' },
-  afternoon: { start: '12:00', end: '17:59' },
-  evening: { start: '18:00', end: '23:59' },
-};
+import { useSettings } from '@/contexts/SettingsContext';
 
 interface Availability {
   week_start: string;
@@ -36,6 +32,7 @@ interface SchedulerProps {
 export default function Component(props: SchedulerProps) {
   const [draft_shifts, setDraftShifts] = useState<Shift[]>([]);
   const { employees } = useSupabaseData();
+  const { timeSpans } = useSettings();
   const selectedWeek = parseISO(props.weekStart);
   const days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
   const days_objs = days.map((day, index) => addDays(selectedWeek, index));
@@ -168,32 +165,32 @@ export default function Component(props: SchedulerProps) {
                 )}
               </div>
             ))}
-            {Object.entries(timeSpans).map(([span]) => (
-              <React.Fragment key={span}>
+            {timeSpans.map((span) => (
+              <React.Fragment key={span.id}>
                 <div className="bg-background/80 p-4 font-semibold capitalize">
-                  {span}
+                  {span.name}
                 </div>
-                
+
                 {days_objs.map((day, dayIndex) => {
-                  const filteredShifts = draft_shifts?.filter(shift => 
-                    isSameDay(shift.date, day) && 
-                    isWithinInterval(parseISO(`2000-01-01T${shift.start_time}`), { 
-                      start: parseISO(`2000-01-01T${timeSpans[span as keyof typeof timeSpans].start}`), 
-                      end: parseISO(`2000-01-01T${timeSpans[span as keyof typeof timeSpans].end}`) 
+                  const filteredShifts = draft_shifts?.filter(shift =>
+                    isSameDay(shift.date, day) &&
+                    isWithinInterval(parseISO(`2000-01-01T${shift.start_time}`), {
+                      start: parseISO(`2000-01-01T${span.start_time}`),
+                      end: parseISO(`2000-01-01T${span.end_time}`)
                     })
                   );
 
                   return (
-                    <div key={`${format(day, 'yyyy-MM-dd')}-${span}`} className="bg-background p-2 min-h-[120px] w-full">
+                    <div key={`${format(day, 'yyyy-MM-dd')}-${span.id}`} className="bg-background p-2 min-h-[120px] w-full">
                       {filteredShifts?.sort(function(a,b){return a.start_time.localeCompare(b.start_time)}).map((shift, index) => {
                         const employee = employees?.find(emp => emp.user_id === shift.user_id);
                         const startTime = parseISO(`2000-01-01T${shift.start_time}`);
-                        
+
                         return (
-                          <DropdownMenu key={`${shift.user_id}-${dayIndex}-${span}-${index}`} >
+                          <DropdownMenu key={`${shift.user_id}-${dayIndex}-${span.id}-${index}`} >
                             <DropdownMenuTrigger asChild className='w-full'>
-                              <div 
-                                key={`${shift.user_id}-${dayIndex}-${span}-${index}`} 
+                              <div
+                                key={`${shift.user_id}-${dayIndex}-${span.id}-${index}`}
                                 className={clsx("text-sm bg-background/10 border rounded p-2 mb-1 flex flex-col select-none cursor-pointer w-full",shift.status==='availability'&&'bg-green-300 border-green-500',shift.status==='open' && 'bg-blue-300 border-blue-500')}
                               >
                                 <div className="flex justify-between items-center font-semibold truncate">{employee?.name}</div>

--- a/src/components/admin-panel/settings/AdminSettings.tsx
+++ b/src/components/admin-panel/settings/AdminSettings.tsx
@@ -5,15 +5,12 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Clock, Building2, Users, Bell, Shield } from 'lucide-react';
+import { Clock, Building2, Bell } from 'lucide-react';
+import { useSettings } from '@/contexts/SettingsContext';
+import { TimeSpan } from '@/lib/definitions';
 
 const AdminSettings = () => {
-  // State for time spans
-  const [timeSpans, setTimeSpans] = useState([
-    { id: 1, name: 'Morning', startTime: '06:00', endTime: '14:00' },
-    { id: 2, name: 'Afternoon', startTime: '14:00', endTime: '22:00' },
-    { id: 3, name: 'Night', startTime: '22:00', endTime: '06:00' }
-  ]);
+  const { timeSpans, addTimeSpan, updateTimeSpan } = useSettings();
 
   // State for business settings
   const [businessSettings, setBusinessSettings] = useState({
@@ -24,12 +21,11 @@ const AdminSettings = () => {
     autoSchedule: false
   });
 
-  const handleTimeSpanChange = (id: number, field: string, value: string) => {
-    setTimeSpans(spans =>
-      spans.map(span =>
-        span.id === id ? { ...span, [field]: value } : span
-      )
-    );
+  const handleTimeSpanChange = (id: number, field: keyof Omit<TimeSpan,'id'>, value: string) => {
+    const span = timeSpans.find(s => s.id === id);
+    if (!span) return;
+    const updated = { ...span, [field]: value } as TimeSpan;
+    updateTimeSpan(updated);
   };
 
   return (
@@ -101,21 +97,21 @@ const AdminSettings = () => {
                   <label className="text-sm font-medium">Start Time</label>
                   <Input
                     type="time"
-                    value={span.startTime}
-                    onChange={(e) => handleTimeSpanChange(span.id, 'startTime', e.target.value)}
+                    value={span.start_time}
+                    onChange={(e) => handleTimeSpanChange(span.id, 'start_time', e.target.value)}
                   />
                 </div>
                 <div className="space-y-2">
                   <label className="text-sm font-medium">End Time</label>
                   <Input
                     type="time"
-                    value={span.endTime}
-                    onChange={(e) => handleTimeSpanChange(span.id, 'endTime', e.target.value)}
+                    value={span.end_time}
+                    onChange={(e) => handleTimeSpanChange(span.id, 'end_time', e.target.value)}
                   />
                 </div>
               </div>
             ))}
-            <Button variant="outline" className="w-full">
+            <Button variant="outline" className="w-full" onClick={() => addTimeSpan({ name: '', start_time: '', end_time: '' })}>
               Add Time Span
             </Button>
           </div>

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState } from "react";
+import { TimeSpan } from "@/lib/definitions";
+
+interface SettingsContextType {
+  timeSpans: TimeSpan[];
+  addTimeSpan: (span: Omit<TimeSpan, "id">) => Promise<void>;
+  updateTimeSpan: (span: TimeSpan) => Promise<void>;
+}
+
+const SettingsContext = createContext<SettingsContextType | undefined>(
+  undefined
+);
+
+export const SettingsProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [timeSpans, setTimeSpans] = useState<TimeSpan[]>([]);
+
+  useEffect(() => {
+    const fetchSpans = async () => {
+      const res = await fetch("/api/time-spans", { cache: "no-store" });
+      if (res.ok) {
+        const data: TimeSpan[] = await res.json();
+        setTimeSpans(data);
+      }
+    };
+    fetchSpans();
+  }, []);
+
+  const addTimeSpan = async (span: Omit<TimeSpan, "id">) => {
+    const res = await fetch("/api/time-spans", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(span),
+    });
+    if (res.ok) {
+      const data: TimeSpan = await res.json();
+      setTimeSpans((prev) => [...prev, data]);
+    }
+  };
+
+  const updateTimeSpan = async (span: TimeSpan) => {
+    const res = await fetch("/api/time-spans", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(span),
+    });
+    if (res.ok) {
+      setTimeSpans((prev) =>
+        prev.map((s) => (s.id === span.id ? { ...span } : s))
+      );
+    }
+  };
+
+  return (
+    <SettingsContext.Provider value={{ timeSpans, addTimeSpan, updateTimeSpan }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+};
+
+export const useSettings = () => {
+  const ctx = useContext(SettingsContext);
+  if (!ctx) {
+    throw new Error("useSettings must be used within a SettingsProvider");
+  }
+  return ctx;
+};

--- a/src/lib/definitions.ts
+++ b/src/lib/definitions.ts
@@ -54,3 +54,10 @@ export type AvailabilityTable= {
       [key: string]: { start: string; end: string }[];
     };
 }
+
+export type TimeSpan = {
+    id: number;
+    name: string;
+    start_time: string;
+    end_time: string;
+};

--- a/supabase/migrations/20240606120000_create_time_spans.sql
+++ b/supabase/migrations/20240606120000_create_time_spans.sql
@@ -1,0 +1,6 @@
+create table if not exists time_spans (
+  id serial primary key,
+  name text not null,
+  start_time time not null,
+  end_time time not null
+);


### PR DESCRIPTION
## Summary
- add Supabase migration and API for `time_spans`
- introduce SettingsContext to sync spans with backend
- wire AdminSettings and Scheduler to use new time spans

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68961e106978833389525a1658421ebf