### PR TITLE
feat: add employee registration page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "lucide-react": "^0.377.0",
         "next": "14.2.3",
         "next-themes": "^0.3.0",
+        "nodemailer": "^7.0.5",
         "react": "^18",
         "react-day-picker": "^9.0.9",
         "react-dom": "^18",
@@ -40,6 +41,7 @@
       },
       "devDependencies": {
         "@types/node": "^20",
+        "@types/nodemailer": "^6.4.17",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "eslint": "^8",
@@ -3687,6 +3689,16 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
+      "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/phoenix": {
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.5.tgz",
@@ -6481,6 +6493,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.5.tgz",
+      "integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/normalize-path": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lucide-react": "^0.377.0",
     "next": "14.2.3",
     "next-themes": "^0.3.0",
+    "nodemailer": "^7.0.5",
     "react": "^18",
     "react-day-picker": "^9.0.9",
     "react-dom": "^18",
@@ -41,6 +42,7 @@
   },
   "devDependencies": {
     "@types/node": "^20",
+    "@types/nodemailer": "^6.4.17",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "eslint": "^8",

--- a/src/app/api/send-email/route.ts
+++ b/src/app/api/send-email/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import nodemailer from 'nodemailer';
+
+type EmailRequestBody = {
+  name: string;
+  email: string;
+  message: string;
+};
+
+export async function POST(req: NextRequest) {
+  const { name, email, message } = (await req.json()) as EmailRequestBody;
+
+  const { GMAIL_USERNAME, GMAIL_PASSWORD } = process.env;
+  if (!GMAIL_USERNAME || !GMAIL_PASSWORD) {
+    return NextResponse.json({ message: 'Email env vars not set.' }, { status: 500 });
+  }
+
+  const transporter = nodemailer.createTransport({
+    host: 'smtp.gmail.com',
+    port: 587,
+    secure: false,
+    auth: {
+      user: GMAIL_USERNAME,
+      pass: GMAIL_PASSWORD,
+    },
+  });
+
+  try {
+    await transporter.sendMail({
+      from: GMAIL_USERNAME,
+      to: 'recipient@example.com',
+      subject: `New message from ${name}`,
+      text: message,
+      replyTo: email,
+    });
+
+    return NextResponse.json({ message: 'Email sent successfully!' }, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ message: 'Failed to send email.' }, { status: 500 });
+  }
+}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,90 @@
+import Link from 'next/link'
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { SubmitButton } from '@/components/login/submit-button'
+import { createClient } from '@/utils/supabase/server'
+import { redirect } from 'next/navigation'
+
+export default function RegisterPage() {
+
+  const signUp = async (formData: FormData) => {
+    "use server";
+
+    const supabase = createClient();
+
+    const username = formData.get("username") as string;
+    const firstName = formData.get("first_name") as string;
+    const lastName = formData.get("last_name") as string;
+    const email = formData.get("email") as string;
+    const password = formData.get("password") as string;
+
+    const { data, error } = await supabase.auth.signUp({
+      email,
+      password,
+    });
+
+    if (error || !data.user) {
+      return redirect("/register?message=Could not create user");
+    }
+
+    const { error: insertError } = await supabase.from('profiles').insert({
+      id: data.user.id,
+      username,
+      first_name: firstName,
+      last_name: lastName,
+      email,
+      role: 'employee'
+    });
+
+    if (insertError) {
+      return redirect("/register?message=Could not create profile");
+    }
+
+    return redirect("/login");
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+      <Card className="w-[350px]">
+        <CardHeader>
+          <CardTitle>Register</CardTitle>
+          <CardDescription>Create a new employee account</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form>
+            <div className="grid w-full items-center gap-4 pb-3">
+              <div className="flex flex-col space-y-1.5">
+                <Label htmlFor="username">Username</Label>
+                <Input id="username" name="username" placeholder="Enter a username" required />
+              </div>
+              <div className="flex flex-col space-y-1.5">
+                <Label htmlFor="first_name">First Name</Label>
+                <Input id="first_name" name="first_name" placeholder="Enter your first name" required />
+              </div>
+              <div className="flex flex-col space-y-1.5">
+                <Label htmlFor="last_name">Last Name</Label>
+                <Input id="last_name" name="last_name" placeholder="Enter your last name" required />
+              </div>
+              <div className="flex flex-col space-y-1.5">
+                <Label htmlFor="email">Email</Label>
+                <Input id="email" name="email" type="email" placeholder="Enter your email" required />
+              </div>
+              <div className="flex flex-col space-y-1.5">
+                <Label htmlFor="password">Password</Label>
+                <Input id="password" name="password" type="password" placeholder="Create a password" required />
+              </div>
+            </div>
+            <SubmitButton formAction={signUp} pendingText="Signing Up...">Register</SubmitButton>
+          </form>
+        </CardContent>
+        <CardFooter className="flex justify-center">
+          <p className="text-sm text-gray-600">
+            Already have an account?{' '}
+            <Link href="/login" className="text-blue-600 hover:underline">Login here</Link>
+          </p>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -28,16 +28,18 @@ export default function RegisterPage() {
       return redirect("/register?message=Could not create user");
     }
 
-    const { error: insertError } = await supabase.from('profiles').insert({
-      id: data.user.id,
-      username,
-      first_name: firstName,
-      last_name: lastName,
-      email,
-      role: 'employee'
-    });
+    const { error: profileError } = await supabase
+      .from('profiles')
+      .upsert({
+        id: data.user.id,
+        username,
+        first_name: firstName,
+        last_name: lastName,
+        email,
+        role: 'employee',
+      });
 
-    if (insertError) {
+    if (profileError) {
       return redirect("/register?message=Could not create profile");
     }
 

--- a/src/components/admin-panel/employees/add-employee-dialog.tsx
+++ b/src/components/admin-panel/employees/add-employee-dialog.tsx
@@ -11,9 +11,12 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 
 export function AddEmployeeDialog() {
   const [open, setOpen] = useState(false);
+  const [showPassword, setShowPassword] = useState(true);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
 
@@ -24,6 +27,10 @@ export function AddEmployeeDialog() {
       setPassword(generated);
     }
   };
+  const generateRandomPassword = () => {
+    const generated = crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+    setPassword(generated);
+  }
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -36,18 +43,57 @@ export function AddEmployeeDialog() {
         <DialogHeader>
           <DialogTitle>Register Employee</DialogTitle>
         </DialogHeader>
-        <div className="space-y-4">
-          <Input
-            type="email"
-            placeholder="Email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-          />
-          <Input type="text" value={password} readOnly />
+        <div className=" grid gap-4">
+          <div className="grid gap-1">
+            <Label>Email</Label>
+            <Input
+              type="email"
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+
+          </div>
+          <div className="grid gap-1">
+            <Label htmlFor="password">Password</Label>
+            <div className="flex gap-2">
+              <Input
+                id="password"
+                name="password"
+                type={showPassword ? "text" : "password"}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                autoComplete="new-password"
+                aria-describedby="password-help"
+                aria-live="polite"
+                spellCheck={false}
+                className="flex-1"
+              />
+              <Button type="button" variant="secondary" onClick={generateRandomPassword}>
+                Generate
+              </Button>
+            </div>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="show-password"
+              checked={showPassword}
+              onCheckedChange={() => { setShowPassword(!showPassword) }}
+              aria-controls="password"
+              aria-label="Show password"
+              className="mt-0.5"
+            />
+            <Label htmlFor="show-password" className="cursor-pointer text-sm font-medium">
+              Show password
+            </Label>
+          </div>
+
+          </div>
           <Button className="w-full">Register &amp; Send email</Button>
+
         </div>
+
       </DialogContent>
-    </Dialog>
+    </Dialog >
   );
 }
 

--- a/src/components/admin-panel/employees/add-employee-dialog.tsx
+++ b/src/components/admin-panel/employees/add-employee-dialog.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+
+export function AddEmployeeDialog() {
+  const [open, setOpen] = useState(false);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleOpenChange = (isOpen: boolean) => {
+    setOpen(isOpen);
+    if (isOpen) {
+      const generated = crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+      setPassword(generated);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button size="icon" aria-label="Add employee">
+          <Plus className="h-4 w-4" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Register Employee</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <Input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <Input type="text" value={password} readOnly />
+          <Button className="w-full">Register &amp; Send email</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/src/components/admin-panel/employees/employeestable.tsx
+++ b/src/components/admin-panel/employees/employeestable.tsx
@@ -91,7 +91,7 @@ export default function ProfilesPage() {
 
   return (
     <Card className="rounded-lg border-none mt-6">
-        <CardHeader className="flex items-center justify-between">
+        <CardHeader className="flex flex-row items-center justify-between">
             <CardTitle >Employees list</CardTitle>
             <AddEmployeeDialog />
         </CardHeader>

--- a/src/components/admin-panel/employees/employeestable.tsx
+++ b/src/components/admin-panel/employees/employeestable.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Avatar,AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { EmployeeInfoDialog } from './employee-info-dialog'
 import { fetchEmployees } from '@/utils/api'
+import { AddEmployeeDialog } from "./add-employee-dialog"
 
 interface Profile {
   id: string
@@ -90,8 +91,9 @@ export default function ProfilesPage() {
 
   return (
     <Card className="rounded-lg border-none mt-6">
-        <CardHeader>
+        <CardHeader className="flex items-center justify-between">
             <CardTitle >Employees list</CardTitle>
+            <AddEmployeeDialog />
         </CardHeader>
         <CardContent>
             <Table>


### PR DESCRIPTION
## Summary
- add register page with server action to create employee accounts
- store user profile with employee role during sign up

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68970bdd85288333a7918725434fe8c6