### PR TITLE
feat: add user delete API route

### DIFF
--- a/src/app/api/users/[id]/delete/route.ts
+++ b/src/app/api/users/[id]/delete/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/utils/supabase/server";
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string } },
+) {
+  const supabase = createClient(process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+  try {
+    const { error } = await supabase.auth.admin.deleteUser(params.id);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Failed to delete user";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/components/admin-panel/employees/employeestable.tsx
+++ b/src/components/admin-panel/employees/employeestable.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { createClient } from '@/utils/supabase/client'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Button } from "@/components/ui/button"
 import { Loader2, Trash2 } from "lucide-react"
@@ -20,7 +19,6 @@ export default function ProfilesPage() {
   const [profiles, setProfiles] = useState<Employee[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const supabase = createClient()
 
   useEffect(() => {
     const fetchProfiles = () => {
@@ -42,13 +40,18 @@ export default function ProfilesPage() {
     if (!confirm('Are you sure you want to delete this user?')) return
 
     try {
-      const { error } = await supabase.auth.admin.deleteUser(id)
+      const res = await fetch(`/api/users/${id}/delete`, { method: 'DELETE' })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        setError('Error deleting profile: ' + (data.error || res.statusText))
+        return
+      }
 
       const updatedProfiles = profiles.filter(profile => profile.id !== id)
       setProfiles(updatedProfiles)
 
       const cachedEmployees = localStorage.getItem('employees')
-      
+
       if (cachedEmployees) {
         const updatedEmployees = await fetchEmployees();
         localStorage.setItem('employees', JSON.stringify(updatedEmployees))

--- a/src/utils/supabase/server.ts
+++ b/src/utils/supabase/server.ts
@@ -1,12 +1,12 @@
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { cookies } from "next/headers";
 
-export const createClient = () => {
+export const createClient = (supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!) => {
   const cookieStore = cookies();
 
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    supabaseKey,
     {
       cookies: {
         getAll: () => {


### PR DESCRIPTION
## Summary
- add API route that deletes users via Supabase admin
- allow service-role key in server-side Supabase client
- refactor employee table to use deletion API

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689922bbd7308333b5e2dacd731e753b