### PR TITLE
feat: disable submit during pending state

### DIFF
--- a/src/components/login/submit-button.tsx
+++ b/src/components/login/submit-button.tsx
@@ -2,6 +2,7 @@
 
 import { useFormStatus } from "react-dom";
 import { type ComponentProps } from "react";
+import { Loader2 } from "lucide-react";
 import { Button } from "../ui/button";
 
 type Props = ComponentProps<"button"> & {
@@ -14,8 +15,20 @@ export function SubmitButton({ children, pendingText, ...props }: Props) {
   const isPending = pending && action === props.formAction;
 
   return (
-    <Button {...props} type="submit" aria-disabled={pending}>
-      {isPending ? pendingText : children}
+    <Button
+      {...props}
+      type="submit"
+      disabled={isPending}
+      aria-disabled={isPending}
+    >
+      {isPending ? (
+        <>
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          {pendingText}
+        </>
+      ) : (
+        children
+      )}
     </Button>
   );
 }


### PR DESCRIPTION
## Summary
- disable login submit button while pending
- show spinning loader when pending

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a2001d3848333919d7f88156fc41a