### PR TITLE
feat: apply theme tokens to auth pages

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -38,7 +38,7 @@ export default function LoginPage({ searchParams }: { searchParams: { email?: st
   };
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+    <div className="flex items-center justify-center min-h-screen bg-background dark:bg-background">
       <Card className="w-[350px]">
         <CardHeader>
           <CardTitle>Login</CardTitle>

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -47,7 +47,7 @@ export default function RegisterPage({ searchParams }: { searchParams: { message
   };
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+    <div className="flex items-center justify-center min-h-screen bg-background dark:bg-background">
       <Card className="w-[350px]">
         <CardHeader>
           <CardTitle>Register</CardTitle>


### PR DESCRIPTION
## Summary
- replace hard-coded gray backgrounds in auth pages with `bg-background` token

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a21626f9c8333a89823a652a26e98