### PR TITLE
feat: add dynamic admin dashboard summary

### DIFF
--- a/src/components/admin-panel/dashboard/dashboardContent.tsx
+++ b/src/components/admin-panel/dashboard/dashboardContent.tsx
@@ -1,71 +1,106 @@
 'use client'
-import { CalendarIcon, Settings, User } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import Calendar from "./cal";
-import ShiftsCard from "./shifts-card";
-import { Table,TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { Badge } from "@/components/ui/badge";
-import { useState } from "react";
 
-export default function DashboardContent(){
-    const [selectedDate,setSelectedDate]=useState<null|Date>(new Date);
-    const handleSelectedDay=(date:Date|null)=>{
-        setSelectedDate(date);
-    } 
-    const upcomingShifts = [
-        { id: 1, date: '2023-06-15', time: '09:00 AM - 05:00 PM', role: 'Cashier' },
-        { id: 2, date: '2023-06-16', time: '02:00 PM - 10:00 PM', role: 'Floor Manager' },
-        { id: 3, date: '2023-06-18', time: '08:00 AM - 04:00 PM', role: 'Barista' },
-    ]
-    return(
-        <main className="flex-1 overflow-y-auto">
-        <div className="max-w-7xl mx-auto py-6 ">
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            <Card className="col-span-1 md:col-span-2 lg:col-span-2">
-              <CardHeader>
-                <CardTitle>Shift Calendar</CardTitle>
-                <CardDescription>View and manage your shifts</CardDescription>
-              </CardHeader>
-              <CardContent className='flex flex-row'>
-                <Calendar onSelectDate={handleSelectedDay} selectionMode="day" areShiftsPresent={true}/>
-                {(selectedDate&&(
-                  <ShiftsCard date={selectedDate}/>
-                ))}
-              </CardContent>
-            </Card>
+import { useEffect, useState, useCallback } from 'react'
+import Link from 'next/link'
+import { User, CalendarIcon, Plane } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useSupabaseData } from '@/contexts/SupabaseContext'
+import { fetchPendingEmployees } from '@/utils/api'
+import { fetchOpenShifts } from '@/utils/supabaseClient'
+import { createClient } from '@/utils/supabase/client'
 
-            <Card>
-              <CardHeader>
-                <CardTitle>Upcoming Shifts</CardTitle>
-                <CardDescription>Your next 3 scheduled shifts</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Date</TableHead>
-                      <TableHead>Time</TableHead>
-                      <TableHead>Role</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {upcomingShifts.map((shift) => (
-                      <TableRow key={shift.id}>
-                        <TableCell>{shift.date}</TableCell>
-                        <TableCell>{shift.time}</TableCell>
-                        <TableCell>
-                          <Badge variant="outline">{shift.role}</Badge>
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </CardContent>
-            </Card>
+const supabase = createClient()
 
-          </div>
+export default function DashboardContent() {
+  const { employees } = useSupabaseData()
+  const [pendingEmployees, setPendingEmployees] = useState(0)
+  const [openShifts, setOpenShifts] = useState(0)
+  const [pendingVacations, setPendingVacations] = useState(0)
+
+  const refreshCounts = useCallback(async () => {
+    try {
+      const [pending, open, vacations] = await Promise.all([
+        fetchPendingEmployees().then(res => res?.length || 0).catch(() => 0),
+        fetchOpenShifts(new Date()).then(res => res?.length || 0).catch(() => 0),
+        supabase
+          .from('vacations_requests')
+          .select('*', { count: 'exact', head: true })
+          .eq('status', 'pending')
+          .then(({ count }) => count || 0)
+      ])
+      setPendingEmployees(pending)
+      setOpenShifts(open)
+      setPendingVacations(vacations)
+    } catch (err) {
+      console.error('Error fetching dashboard data:', err)
+    }
+  }, [])
+
+  useEffect(() => {
+    refreshCounts()
+    const channel = supabase
+      .channel('dashboard_counts')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'pending_employees' }, refreshCounts)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'open_shifts' }, refreshCounts)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'vacations_requests' }, refreshCounts)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'employees' }, refreshCounts)
+      .subscribe()
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [refreshCounts])
+
+  const totalEmployees = employees?.length || 0
+
+  return (
+    <main className="flex-1 overflow-y-auto">
+      <div className="max-w-7xl mx-auto py-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Employees</CardTitle>
+              <User className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{totalEmployees}</div>
+              <p className="text-xs text-muted-foreground">{pendingEmployees} pending approval</p>
+              <Button asChild variant="outline" className="mt-4">
+                <Link href="/employees">Go to Employees</Link>
+              </Button>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Schedule</CardTitle>
+              <CalendarIcon className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{openShifts}</div>
+              <p className="text-xs text-muted-foreground">Open shifts this week</p>
+              <Button asChild variant="outline" className="mt-4">
+                <Link href="/schedule">Go to Schedule</Link>
+              </Button>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Vacations</CardTitle>
+              <Plane className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{pendingVacations}</div>
+              <p className="text-xs text-muted-foreground">Pending requests</p>
+              <Button asChild variant="outline" className="mt-4">
+                <Link href="/vacations">Go to Vacations</Link>
+              </Button>
+            </CardContent>
+          </Card>
         </div>
-      </main>
-    )
+      </div>
+    </main>
+  )
 }
+


### PR DESCRIPTION
## Summary
- replace worker dashboard content with admin summary cards
- aggregate counts for employees, open shifts, and vacation requests
- update metrics dynamically via Supabase realtime

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689af72e64ac8333b55efd50b97a8782