### PR TITLE
feat: add pending employees card

### DIFF
--- a/src/components/admin-panel/dashboard/PendingEmployeesCard.tsx
+++ b/src/components/admin-panel/dashboard/PendingEmployeesCard.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { fetchPendingEmployees } from '@/utils/api'
+import { PendingEmployee } from '@/lib/definitions'
+
+export default function PendingEmployeesCard() {
+  const [pending, setPending] = useState<PendingEmployee[]>([])
+
+  useEffect(() => {
+    fetchPendingEmployees()
+      .then(res => setPending(res || []))
+      .catch(() => setPending([]))
+  }, [])
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Pending Employees</CardTitle>
+        <CardDescription>Awaiting approval</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {pending.length ? (
+          <ul className="space-y-2">
+            {pending.slice(0, 5).map(emp => (
+              <li key={emp.id} className="flex items-center justify-between">
+                <span>{emp.username || emp.email}</span>
+                <div className="space-x-2">
+                  <Button size="sm" asChild>
+                    <Link href={`/employees?id=${emp.id}&action=approve`}>Approve</Link>
+                  </Button>
+                  <Button size="sm" variant="destructive" asChild>
+                    <Link href={`/employees?id=${emp.id}&action=reject`}>Reject</Link>
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-muted-foreground">No pending employees.</p>
+        )}
+        <Button asChild variant="outline" className="w-full">
+          <Link href="/employees">Go to Employees</Link>
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/admin-panel/dashboard/dashboardContent.tsx
+++ b/src/components/admin-panel/dashboard/dashboardContent.tsx
@@ -14,6 +14,7 @@ import ShiftsCard from "./shifts-card";
 import { Table,TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import OpenShiftsCard from "./OpenShiftsCard";
+import PendingEmployeesCard from "./PendingEmployeesCard";
 
 
 const supabase = createClient()
@@ -105,6 +106,7 @@ export default function DashboardContent() {
             </CardContent>
           </Card>
           <OpenShiftsCard />
+          <PendingEmployeesCard />
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- display pending employees on dashboard with approval links
- integrate pending employees card into dashboard layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689afffa665883339e786b3ee9304814