### PR TITLE
Add vacation requests dashboard card

### DIFF
--- a/src/components/admin-panel/dashboard/VacationRequestsCard.tsx
+++ b/src/components/admin-panel/dashboard/VacationRequestsCard.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Plane } from 'lucide-react'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { createClient } from '@/utils/supabase/client'
+
+export default function VacationRequestsCard() {
+  const [pending, setPending] = useState(0)
+  const supabase = createClient()
+
+  useEffect(() => {
+    const fetchPending = async () => {
+      const { count } = await supabase
+        .from('vacations_requests')
+        .select('*', { count: 'exact', head: true })
+        .eq('status', 'pending')
+      setPending(count ?? 0)
+    }
+
+    fetchPending()
+
+    const channel = supabase
+      .channel('vacation_requests_count')
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'vacations_requests' },
+        fetchPending
+      )
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [supabase])
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">Vacations</CardTitle>
+        <Plane className="h-4 w-4 text-muted-foreground" />
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold">{pending}</div>
+        <p className="text-xs text-muted-foreground">Pending requests</p>
+        <Button asChild variant="outline" className="mt-4">
+          <Link href="/vacations">Go to Vacations</Link>
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}
+

--- a/src/components/admin-panel/dashboard/dashboardContent.tsx
+++ b/src/components/admin-panel/dashboard/dashboardContent.tsx
@@ -2,18 +2,15 @@
 
 import { useEffect, useState, useCallback } from 'react'
 import Link from 'next/link'
-import { User, CalendarIcon, Plane } from 'lucide-react'
+import { User, CalendarIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent,CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { useSupabaseData } from '@/contexts/SupabaseContext'
 import { fetchPendingEmployees } from '@/utils/api'
 import { fetchOpenShifts } from '@/utils/supabaseClient'
 import { createClient } from '@/utils/supabase/client'
-import Calendar from "./cal";
-import ShiftsCard from "./shifts-card";
-import { Table,TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { Badge } from "@/components/ui/badge";
 import OpenShiftsCard from "./OpenShiftsCard";
+import VacationRequestsCard from "./VacationRequestsCard";
 
 
 const supabase = createClient()
@@ -22,22 +19,15 @@ export default function DashboardContent() {
   const { employees } = useSupabaseData()
   const [pendingEmployees, setPendingEmployees] = useState(0)
   const [openShifts, setOpenShifts] = useState(0)
-  const [pendingVacations, setPendingVacations] = useState(0)
 
   const refreshCounts = useCallback(async () => {
     try {
-      const [pending, open, vacations] = await Promise.all([
+      const [pending, open] = await Promise.all([
         fetchPendingEmployees().then(res => res?.length || 0).catch(() => 0),
         fetchOpenShifts(new Date()).then(res => res?.length || 0).catch(() => 0),
-        supabase
-          .from('vacations_requests')
-          .select('*', { count: 'exact', head: true })
-          .eq('status', 'pending')
-          .then(({ count }) => count || 0)
       ])
       setPendingEmployees(pending)
       setOpenShifts(open)
-      setPendingVacations(vacations)
     } catch (err) {
       console.error('Error fetching dashboard data:', err)
     }
@@ -49,7 +39,6 @@ export default function DashboardContent() {
       .channel('dashboard_counts')
       .on('postgres_changes', { event: '*', schema: 'public', table: 'pending_employees' }, refreshCounts)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'open_shifts' }, refreshCounts)
-      .on('postgres_changes', { event: '*', schema: 'public', table: 'vacations_requests' }, refreshCounts)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'employees' }, refreshCounts)
       .subscribe()
     return () => {
@@ -91,19 +80,7 @@ export default function DashboardContent() {
             </CardContent>
           </Card>
 
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Vacations</CardTitle>
-              <Plane className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{pendingVacations}</div>
-              <p className="text-xs text-muted-foreground">Pending requests</p>
-              <Button asChild variant="outline" className="mt-4">
-                <Link href="/vacations">Go to Vacations</Link>
-              </Button>
-            </CardContent>
-          </Card>
+          <VacationRequestsCard />
           <OpenShiftsCard />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add VacationRequestsCard component to show pending vacation approvals
- integrate card into dashboard layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b0108269883339cc7373dfeb7515f